### PR TITLE
mask the nric or foreign id in logs wherever the ID is displayed

### DIFF
--- a/lib/corp_pass/nric_helper.rb
+++ b/lib/corp_pass/nric_helper.rb
@@ -1,0 +1,23 @@
+module NricHelper
+  def self.mask_xml_nric(user_info)
+    doc = Nokogiri::XML(user_info)
+    if doc.at_xpath('//CPUID').present?
+      nric_value = doc.at_xpath('//CPUID').content
+      doc.at_xpath('//CPUID').content = mask_nric(nric_value)
+      doc.to_xml
+    end
+  end
+
+  def self.mask_nric(to_mask)
+    to_mask.gsub(/.(?=.{4})/, 'X')
+  end
+
+  def self.mask_nric_slo_request(request)
+    doc = Nokogiri::XML(request.to_xml)
+    if doc.at_xpath('//saml:NameID').present?
+      nric_value = doc.at_xpath('//saml:NameID').content
+      doc.at_xpath('//saml:NameID').content = mask_nric(nric_value)
+      doc.to_xml
+    end
+  end
+end

--- a/lib/corp_pass/version.rb
+++ b/lib/corp_pass/version.rb
@@ -1,3 +1,3 @@
 module CorpPass
-  VERSION = '1.0.4'.freeze
+  VERSION = '1.0.6'.freeze
 end

--- a/lib/corp_pass/version.rb
+++ b/lib/corp_pass/version.rb
@@ -1,3 +1,3 @@
 module CorpPass
-  VERSION = '1.0.3'.freeze
+  VERSION = '1.0.4'.freeze
 end


### PR DESCRIPTION
This pull request is to mask all the characters except last 4, of the NRIC/foreign ID when the NRIC/Foreign ID is logged in the logs. This is being done as part of BGP's decision to mask sensitive information in the application logs including corp-pass logs. The logs are masked at 4 places - when slo_request is logged, NRIC present in valid/invalid user xml in authenticate method and when a user has logged in successfully. Please help review the changes. - Preethika 